### PR TITLE
Improve HTTPS config documentation

### DIFF
--- a/docs/howto.html
+++ b/docs/howto.html
@@ -288,6 +288,10 @@ sudo systemctl enable miniflux.service
 
 <h2 id="lets-encrypt">Let's Encrypt Configuration <a class="anchor" href="#lets-encrypt" title="Permalink">¶</a></h2>
 
+<div class="info">
+<b>Note:</b> This does not work if you're running miniflux behind a reverse proxy using Nginx or Apache. To use Let's Encrypt in that setting, please refer to the documentation over at <a href="https://letsencrypt.org">letsencrypt.org</a>
+</div>
+
 <p>You could use Let&rsquo;s Encrypt to manage the SSL certificate automatically and activate HTTP/2.</p>
 
 <pre><code class="language-bash">export CERT_DOMAIN=my.domain.tld
@@ -305,6 +309,10 @@ Miniflux supports http-01 challenge since the version 2.0.2.
 </div>
 
 <h2 id="https">Manual HTTPS Configuration <a class="anchor" href="#https" title="Permalink">¶</a></h2>
+
+<div class="info">
+<b>Note:</b> This does not work if you're running miniflux behind a reverse proxy using Nginx or Apache. To use Let's Encrypt in that setting, please refer to the documentation over at <a href="https://letsencrypt.org">letsencrypt.org</a>
+</div>
 
 <p>Here an example to generate a self-signed certificate:</p>
 

--- a/feed.xml
+++ b/feed.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
   <title>Miniflux</title>
   <id>https://miniflux.app/</id>
-  <updated>2019-05-03T20:10:24-07:00</updated>
+  <updated>2019-06-05T21:14:31&#43;02:00</updated>
   <author>
     <name>Frédéric Guillot</name>
   </author>

--- a/src/docs/howto.md
+++ b/src/docs/howto.md
@@ -280,6 +280,10 @@ If you watch the logs with `journalctl -u miniflux.service`, you will see `[INFO
 
 <h2 id="lets-encrypt">Let's Encrypt Configuration <a class="anchor" href="#lets-encrypt" title="Permalink">¶</a></h2>
 
+<div class="info">
+<b>Note:</b> This does not work if you're running miniflux behind a reverse proxy using Nginx or Apache. To use Let's Encrypt in that setting, please refer to the documentation over at <a href="https://letsencrypt.org">letsencrypt.org</a>
+</div>
+
 You could use Let's Encrypt to manage the SSL certificate automatically and activate HTTP/2.
 
 ```bash
@@ -296,6 +300,10 @@ Miniflux supports http-01 challenge since the version 2.0.2.
 </div>
 
 <h2 id="https">Manual HTTPS Configuration <a class="anchor" href="#https" title="Permalink">¶</a></h2>
+
+<div class="info">
+<b>Note:</b> This does not work if you're running miniflux behind a reverse proxy using Nginx or Apache. To use Let's Encrypt in that setting, please refer to the documentation over at <a href="https://letsencrypt.org">letsencrypt.org</a>
+</div>
 
 Here an example to generate a self-signed certificate:
 


### PR DESCRIPTION
Just a little addition to the docs clarifying that HTTPS config via miniflux does not work when running behind a reverse proxy. It's something I stumbled over when I installed the app today. (I'm not much of a sysadmin :wink: )