### PR TITLE
Indentation problem in docker-compose example.

### DIFF
--- a/src/docs/installation.md
+++ b/src/docs/installation.md
@@ -186,7 +186,7 @@ You could also use Docker Compose. Here an example of `docker-compose.yml` file:
 version: '3'
 services:
     miniflux:
-    image: miniflux/miniflux:latest
+        image: miniflux/miniflux:latest
         ports:
             - "80:8080"
         depends_on:


### PR DESCRIPTION
Many thanks for miniflux - I believe there may be an indentation problem in the docker-compose example. Thanks.