### PR TITLE
Increase body text (dd) font-weight to 400

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -135,7 +135,7 @@ dd {
     padding-left: 10px;
     line-height: 1.4em;
     color: #999;
-    font-weight: 300;
+    font-weight: 400;
 }
 
 dd strong {


### PR DESCRIPTION
A font-weight of 300 for body text is often unreadable at normal distances. This PR simply sets it to 400, which should be a lot more readable on more devices.

300:
<img src="https://user-images.githubusercontent.com/11722318/66149395-fc396180-e64d-11e9-8918-0a80385887d1.jpg"/>

400:
<img src="https://user-images.githubusercontent.com/11722318/66150117-761e1a80-e64f-11e9-81ee-f087ab05ef69.jpeg"/>

On my device, this does make the `<strong>` elements appear the same, though this could just be my system font missing a 500 weight version. This can be fixed by using 600 instead, which is also more consistent with the **Paid Hosting** link.