### PR TITLE
Update faq.md

### DIFF
--- a/src/faq.md
+++ b/src/faq.md
@@ -110,4 +110,4 @@ standard_init_linux.go:178: exec user process caused "exec format error"
 
 <h2 id="backup">How to backup my data? <a class="anchor" href="#backup" title="Permalink">¶</a></h2>
 
-Just use standard Postgresql tools: [pgdump](https://www.postgresql.org/docs/current/app-pgdump.html)
+You can use standard Postgresql tools: [pgdump](https://www.postgresql.org/docs/current/app-pgdump.html)


### PR DESCRIPTION
Remove "just". Turns out that if you're not careful, restoring the dump may not work as expected. For instance, I had one error because I did not use `--data-only` and pg_restore tried to re-create the schema, and I _also_ got an error while trying to restore the user's table. Long story short, removing the `just` word can prevent naive users to get stuck with un-recoverable backups.