### PR TITLE
Python client requires named arg for API token

### DIFF
--- a/src/docs/api.md
+++ b/src/docs/api.md
@@ -115,7 +115,7 @@ import miniflux
 client = miniflux.Client("https://miniflux.example.org", "my_username", "my_secret_password")
 
 # Authentication using an API token
-client = miniflux.Client("https://miniflux.example.org", "My Secret Token")
+client = miniflux.Client("https://miniflux.example.org", api_key="My Secret Token")
 
 # Get all feeds
 feeds = client.get_feeds()


### PR DESCRIPTION
The `Client` constructor requires the use of a named argument to specify the API token. Updated docs to reflect this.

```
def __init__(self, base_url: str,
                 username: str = None, password: str = None,
                 timeout: float = 30.0, api_key: str = None)
```