### PR TITLE
Change aarch6 to aarch64 in faq.md

### DIFF
--- a/src/faq.md
+++ b/src/faq.md
@@ -90,7 +90,7 @@ A, A+, B, B+, Zero  | Not supported yet
 Server Type    | Miniflux Binary       | uname -m
 ---------------|-----------------------|---------
 Scaleway C1    | miniflux-linux-armv6  |  armv7l
-Scaleway ARM64 | miniflux-linux-armv8  |  aarch6
+Scaleway ARM64 | miniflux-linux-armv8  |  aarch64
 
 <h2 id="docker-arch">Which Docker architecture should I use? <a class="anchor" href="#docker-arch" title="Permalink">¶</a></h2>
 
@@ -101,7 +101,7 @@ Docker Architecture | uname -m | Example
 amd64               |  x86_64  |
 arm32v6             |  armhf   | Raspberry Pi
 arm32v6             |  armv7l  | Scaleway C1
-arm64v8             |  aarch6  | Scaleway ARM64
+arm64v8             |  aarch64 | Scaleway ARM64
 
 If you use the wrong architecture, Docker will returns an error like this one:
 


### PR DESCRIPTION
`uname -m` returns `aarch64` on armv8 machines, not `aarch6`.
Example from an RK3399 system:
```
~$ lscpu
Architecture:        aarch64
Byte Order:          Little Endian
CPU(s):              6
On-line CPU(s) list: 0-5
Thread(s) per core:  1
Core(s) per socket:  3
Socket(s):           2
Vendor ID:           ARM
Model:               4
Model name:          Cortex-A53
Stepping:            r0p4
CPU max MHz:         1800.0000
CPU min MHz:         408.0000
BogoMIPS:            48.00
Flags:               fp asimd evtstrm aes pmull sha1 sha2 crc32
~$ uname -m
aarch64
```