### PR TITLE
remove references to now-unused CERT_CACHE

### DIFF
--- a/content/docs/configuration.md
+++ b/content/docs/configuration.md
@@ -149,11 +149,6 @@ The configuration file is loaded first if specified. Environment variables takes
         <p>Use <a href="https://letsencrypt.org/">Let's Encrypt</a> to get automatically a certificate for the domain specified in <code>$CERT_DOMAIN</code>.</p>
         <p><em>Default is empty.</em></p>
     </dd>
-    <dt id="cert-cache"><a href="#cert-cache"><code>CERT_CACHE</code></a></dt>
-    <dd>
-        <p>Let's Encrypt cache directory.</p>
-        <p><em>Default is <code>/tmp/cert_cache</code></em></p>
-    </dd>
     <dt id="metrics-collector"><a href="#metrics-collector"><code>METRICS_COLLECTOR</code></a></dt>
     <dd>
         <p>Set to <code>1</code> to enable metrics collection. It exposes a <code>/metrics</code> endpoint that can be used with <a href="https://prometheus.io/">Prometheus Monitoring software</a>.</p>

--- a/content/docs/howto.md
+++ b/content/docs/howto.md
@@ -289,7 +289,6 @@ miniflux
 
 - Your server must be reachable publicly on port 443 and port 80 (http-01 challenge)
 - In this mode, `LISTEN_ADDR` is automatically set to `:https`
-- A cache directory is required, by default `/tmp/cert_cache` is used, it could be overrided by using the variable `CERT_CACHE`
 
 <div class="note">
 Miniflux supports http-01 challenge since the version 2.0.2.

--- a/static/miniflux.1.html
+++ b/static/miniflux.1.html
@@ -172,8 +172,6 @@ The configuration file is a text file that follow these rules:
   <dd>Path to SSL private key.</dd>
   <dt><b>CERT_DOMAIN</b></dt>
   <dd>Use Let's Encrypt to get automatically a certificate for this domain.</dd>
-  <dt><b>CERT_CACHE</b></dt>
-  <dd>Let's Encrypt cache directory (default is /tmp/cert_cache).</dd>
   <dt><b>METRICS_COLLECTOR</b></dt>
   <dd>Set to 1 to enable metrics collector. Expose a /metrics endpoint for
       Prometheus.


### PR DESCRIPTION
Remove references to the LetsEncrypt CERT_CACHE now that it is no longer used on HEAD.