### PR TITLE
Update docker hub installation link

### DIFF
--- a/content/docs/installation.md
+++ b/content/docs/installation.md
@@ -183,7 +183,7 @@ service miniflux start
 
 **Docker Registries:**
 
-- Docker Hub: `docker.io/miniflux/miniflux`
+- Docker Hub: `hub.docker.com/r/miniflux/miniflux`
 - GitHub Container Registry: `ghcr.io/miniflux/miniflux`
 
 **Docker Architectures:**


### PR DESCRIPTION
Requesting the previous URL (`docker.io/miniflux/miniflux`) returns a
`404 - Not Found`. This is the correct URL for `miniflux` on Docker Hub.