### PR TITLE
Fix link to Arch Linux package

### DIFF
--- a/content/docs/installation.md
+++ b/content/docs/installation.md
@@ -20,7 +20,7 @@ Platform       |  Type               |  Repository URL
 Debian/Ubuntu  |  Upstream (Binary)  |  https://github.com/miniflux/v2/tree/master/packaging/debian
 RHEL/Fedora    |  Upstream (Binary)  |  https://github.com/miniflux/v2/tree/master/packaging/rpm
 Alpine Linux   |  Community (Source) |  https://git.alpinelinux.org/aports/tree/community/miniflux
-Arch Linux     |  Community (Source) |  https://aur.archlinux.org/packages/miniflux/
+Arch Linux     |  Community (Source) |  https://archlinux.org/packages/community/x86_64/miniflux/
 FreeBSD Port   |  Community (Source) |  https://svnweb.freebsd.org/ports/head/www/miniflux/
 Nix            |  Community (Source) |  https://github.com/NixOS/nixpkgs/tree/master/pkgs/servers/miniflux
 


### PR DESCRIPTION
It was moved from the AUR to [community] a while ago.