### PR TITLE
Fix link to PWA docs

### DIFF
--- a/content/opinionated.md
+++ b/content/opinionated.md
@@ -69,7 +69,7 @@ Miniflux uses [ECMAScript 6](https://en.wikipedia.org/wiki/ECMAScript#6th_Editio
 
 Using the web UI on your smartphone is not so bad:
 
-- Miniflux is a [progressive web app](https://developer.mozilla.org/en-US/Apps/Progressive>)
+- Miniflux is a [progressive web app](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps)
 - The layout adapts to the screen size (responsive design)
 - You could add the application to the home screen like any native application
 - You can swipe entries horizontally to change their status


### PR DESCRIPTION
This fixes the link to the PWA docs on the **Opinionated** page. Before, the URL was wrong as it had a superfluous trailing `>`.

The old, [corrected URL](https://developer.mozilla.org/en-US/Apps/Progressive) redirects to [a new page](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps), so this changes the URL to the redirect target as well.