### PR TITLE
Update docker compose examples to the latest Compose file format

### DIFF
--- a/content/docs/installation.md
+++ b/content/docs/installation.md
@@ -218,7 +218,6 @@ Running the command above will run the migrations and sets up a new admin accoun
 You could also use Docker Compose. Here an example of `docker-compose.yml` file:
 
 ```yaml
-version: '3.4'
 services:
   miniflux:
     image: miniflux/miniflux:latest
@@ -259,7 +258,6 @@ docker-compose exec miniflux /usr/bin/miniflux -create-admin
 Another way of doing the same thing is to populate the variables `RUN_MIGRATIONS`, `CREATE_ADMIN`, `ADMIN_USERNAME` and `ADMIN_PASSWORD`. For example:
 
 ```yaml
-version: '3.4'
 services:
   miniflux:
     image: miniflux/miniflux:latest

--- a/content/docs/installation.md
+++ b/content/docs/installation.md
@@ -225,7 +225,8 @@ services:
     ports:
       - "80:8080"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       - DATABASE_URL=postgres://miniflux:secret@db/miniflux?sslmode=disable
   db:
@@ -265,7 +266,8 @@ services:
     ports:
       - "80:8080"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       - DATABASE_URL=postgres://miniflux:secret@db/miniflux?sslmode=disable
       - RUN_MIGRATIONS=1

--- a/content/docs/installation.md
+++ b/content/docs/installation.md
@@ -215,7 +215,7 @@ docker run -d \
 
 Running the command above will run the migrations and sets up a new admin account with the chosen username and password.
 
-You could also use Docker Compose. Here an example of `docker-compose.yml` file:
+You could also use Docker Compose. Here is an example of a Compose file:
 
 ```yaml
 services:
@@ -243,16 +243,16 @@ volumes:
   miniflux-db:
 ```
 
-Start the database first `docker-compose up -d db` and then the application `docker-compose up miniflux`.
+Start the application by running `docker compose up -d`.
 
 Remember that you still need to run the database migrations and create the first user:
 
 ```bash
 # Run database migrations
-docker-compose exec miniflux /usr/bin/miniflux -migrate
+docker compose exec miniflux /usr/bin/miniflux -migrate
 
 # Create the first user
-docker-compose exec miniflux /usr/bin/miniflux -create-admin
+docker compose exec miniflux /usr/bin/miniflux -create-admin
 ```
 
 Another way of doing the same thing is to populate the variables `RUN_MIGRATIONS`, `CREATE_ADMIN`, `ADMIN_USERNAME` and `ADMIN_PASSWORD`. For example:


### PR DESCRIPTION
Born from https://github.com/miniflux/v2/issues/1693.

According to the [Compose file versions](https://docs.docker.com/compose/compose-file/compose-versioning/#versioning),

>The latest Compose file format is defined by the [Compose Specification](https://github.com/compose-spec/compose-spec/blob/master/spec.md) and is implemented by Docker Compose 1.27.0+.

This PR is updating the compose files examples in the documentation.

- Add health check condition to `depends_on`, it was re-introduced in the specification after it was removed in v3. Effectively this partially reverts 203c5ee9841269035985233a858ebea433ccab34.
- Remove [deprecated](https://docs.docker.com/compose/compose-file/#version-top-level-element) `version` top-level element.