### PR TITLE
Switch to "run" instead of "exec" to run migrations, as container is still not up

### DIFF
--- a/content/docs/installation.md
+++ b/content/docs/installation.md
@@ -249,10 +249,10 @@ Remember that you still need to run the database migrations and create the first
 
 ```bash
 # Run database migrations
-docker compose exec miniflux /usr/bin/miniflux -migrate
+docker compose run miniflux /usr/bin/miniflux -migrate
 
 # Create the first user
-docker compose exec miniflux /usr/bin/miniflux -create-admin
+docker compose run miniflux /usr/bin/miniflux -create-admin
 ```
 
 Another way of doing the same thing is to populate the variables `RUN_MIGRATIONS`, `CREATE_ADMIN`, `ADMIN_USERNAME` and `ADMIN_PASSWORD`. For example:


### PR DESCRIPTION
Following the docker compose set up, after the first "docker compose up", the miniflux container will fail to start, as the database is not ready yet. Additionally, it won't be possible to "exec" a command in that container, since it failed to start.

I changed the "exec" commands to "run" ones, so the miniflux container is started  with the migration command passed.

After running these two commands (just the first one really is needed) a `docker compose up` (or a docker compose start miniflux) will finally succeed (and only then an exec command can work).

 