### PR TITLE
Add official Debian and Ubuntu packages to installation page

### DIFF
--- a/content/docs/installation.md
+++ b/content/docs/installation.md
@@ -22,7 +22,9 @@ Debian/Ubuntu  |  Upstream (Binary)  |  https://github.com/miniflux/v2/tree/mast
 RHEL/Fedora    |  Upstream (Binary)  |  https://github.com/miniflux/v2/tree/master/packaging/rpm
 Alpine Linux   |  Community (Source) |  https://git.alpinelinux.org/aports/tree/community/miniflux
 Arch Linux     |  Community (Source) |  https://archlinux.org/packages/extra/x86_64/miniflux/
+Debian         |  Community (Binary) |  https://packages.debian.org/trixie/miniflux
 FreeBSD Port   |  Community (Source) |  https://svnweb.freebsd.org/ports/head/www/miniflux/
 Nix            |  Community (Source) |  https://github.com/NixOS/nixpkgs/tree/master/pkgs/servers/miniflux
+Ubuntu         |  Community (Binary) |  https://packages.ubuntu.com/noble/miniflux
 
 You can download precompiled binaries and packages from the [GitHub Releases page](https://github.com/miniflux/v2/releases). You could also [build the application from the source code]({{< ref "development.md" >}}).


### PR DESCRIPTION
Miniflux has just been packaged in Debian, and has appeared in Debian Testing (and Ubuntu Noble as well). So it makes sense to also link to these distro packages in the documentation.

Something to consider is that these packages aren't available on the latest stable versions of Debian and Ubuntu, which are Debian 12 (Bookworm) and Ubuntu 23.10 (Mantic) at the time of writing, and only available via [pinning](https://help.ubuntu.com/community/PinningHowto) or running Testing/Noble on the machine.

Relevant links:

- Debian Package Page: https://packages.debian.org/trixie/miniflux
- Debian Package Tracker: https://tracker.debian.org/pkg/miniflux
- Ubuntu Package Page: https://packages.ubuntu.com/noble/miniflux