### PR TITLE
Update docker compose with POSTGRES_HOST_AUTH_METHOD

### DIFF
--- a/content/docs/docker.md
+++ b/content/docs/docker.md
@@ -80,6 +80,7 @@ services:
       - POSTGRES_USER=miniflux
       - POSTGRES_PASSWORD=secret
       - POSTGRES_DB=miniflux
+      - POSTGRES_HOST_AUTH_METHOD=password
     volumes:
       - miniflux-db:/var/lib/postgresql/data
     healthcheck:


### PR DESCRIPTION
The old compose file doesn't work out of the box because `POSTGRES_HOST_AUTH_METHOD` defaults to `scram-sha-256` rather than `password`. Providing the username and password in `DATABASE_URL` seems to require setting this to `password` in order to authenticate. 

As it is, the old file also creates a hard to debug situation where the `pg_hba.conf` file gets saved to the volume with the first result of running the compose file (containing `scram-sha-256`) and so ignores later attempts to change the authentication method through the environment variable. Fixing this requires users to either edit the file by hand or delete the volume. Both workarounds require the user to have an understanding of postgres & its configuration.

The fix is super simple but isn't recommended for multi-user environments.

References
- https://www.prisma.io/dataguide/postgresql/authentication-and-authorization/configuring-user-authentication