### PR TITLE
docs(rules): add link to predefined scraper rules

### DIFF
--- a/content/docs/rules.md
+++ b/content/docs/rules.md
@@ -199,7 +199,7 @@ saved in the feed properties (Select a feed and click on edit).
 | `div.content` | Fetch all `div` elements with the class `content` |
 | `article, div.article` | Use a comma to define multiple rules |
 
-Miniflux includes a list of predefined rules for popular websites.
+Miniflux includes a list of [predefined rules](https://github.com/miniflux/v2/blob/main/internal/reader/scraper/rules.go) for popular websites.
 You could contribute to the project to keep them up to date.
 
 Under the hood, Miniflux uses the library [Goquery](https://github.com/PuerkitoBio/goquery).


### PR DESCRIPTION
The code file is mentioned but not linked in the docs, causing confusion for myself and [others](https://github.com/orgs/miniflux/discussions/2696).