### PR TITLE
Update Reeder to Reeder Classic

### DIFF
--- a/content/docs/apps.md
+++ b/content/docs/apps.md
@@ -18,7 +18,7 @@ Table of Contents
 - [NewsFlash](https://gitlab.com/news-flash/news_flash_gtk) (Linux / FOSS)
 - [ReactFlux](#ReactFlux) (Web frontend)
 - [Read You](https://github.com/Ashinch/ReadYou) (Android / FOSS)
-- [Reeder](http://reederapp.com/) (iOS/macOS / Paid / Proprietary)
+- [Reeder Classic](http://reederapp.com/classic) (iOS/macOS / Paid / Proprietary)
 - [Reminiflux](#reminiflux) (Web frontend)
 - [RSS Guard](https://github.com/martinrotter/rssguard) (Windows, Linux, BSD, OS/2 or macOS / FOSS)
 - [Telegram](https://telegram.org/)

--- a/content/docs/fever.md
+++ b/content/docs/fever.md
@@ -13,7 +13,7 @@ To activate the Fever API, go to the integration section and choose a username/p
 
 ## Compatible Apps
 
-- [Reeder](http://reederapp.com/) (iOS/macOS)
+- [Reeder Classic](http://reederapp.com/classic) (iOS/macOS)
 - [Unread](https://www.goldenhillsoftware.com/unread/) (iOS)
 - [FeedMe](https://play.google.com/store/apps/details?id=com.seazon.feedme&hl=en) (Android)
 - [FocusReader](https://play.google.com/store/apps/details?id=allen.town.focus.reader) (Android)

--- a/content/docs/google_reader.md
+++ b/content/docs/google_reader.md
@@ -11,7 +11,7 @@ To activate the Google Reader API, go to the **Settings > Integrations** section
 
 ## Compatible Apps
 
-- [Reeder >= 5](http://reederapp.com/) (iOS/macOS)
+- [Reeder Classic >= 5](http://reederapp.com/classic) (iOS/macOS)
 - [RSS Guard](https://github.com/martinrotter/rssguard)
 - [NetNewsWire](https://netnewswire.com/) (iOS/macOS)
 


### PR DESCRIPTION
Reeder has released a new version that does not support external rss services (such as MiniFlux). The old version that does has been renamed to Reeder Classic, and its webpage has moved to https://reederapp.com/classic/.

This pr updates `[Reeder](https://reederapp.com/)` to `[Reeder Classic](https://reederapp.com/classic/)`