### PR TITLE
Add Authentik OIDC Note

### DIFF
--- a/content/docs/howto.md
+++ b/content/docs/howto.md
@@ -338,7 +338,7 @@ You can use the OpenID Connect integration with different providers.
 
 Note that the OIDC library automatically appends the `.well-known/openid-configuration`, this part has to be removed from the URL when setting `OAUTH2_OIDC_DISCOVERY_ENDPOINT`.
 
-For example, Authentik discovery endpoint is `https://authentik.example.org/application/o/miniflux/.well-known/openid-configuration` and the `OAUTH2_OIDC_DISCOVERY_ENDPOINT` config option should be `https://authentik.example.org/application/o/miniflux/`.
+For example, Authentik discovery endpoint is `https://authentik.example.org/application/o/miniflux/.well-known/openid-configuration` and the `OAUTH2_OIDC_DISCOVERY_ENDPOINT` config option should be `https://authentik.example.org/application/o/miniflux/` (note the trailing `/`).
 
 - Since Miniflux 2.0.48, [OAuth2 PKCE](https://oauth.net/2/pkce/) is supported.
 - Since Miniflux 2.0.48, the `profile` scope will be requested in addition to the `email` scope. If no email address is available, Miniflux will fallback to the `preferred_username` or `name` claims to populate Miniflux's `username` field.


### PR DESCRIPTION
If  the trailing `/` is missing from the path, miniflux will report a string mismatch in the logs.

This caught me off-guard today.