### PR TITLE
make site work on latest version of hugo

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -10,7 +10,7 @@ unsafe = true
 [markup.highlight]
 codeFences = false
 
-[author]
+[params.author]
 name = "Frédéric Guillot"
 
 [outputFormats]

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -2,7 +2,7 @@
     <title>{{ .Site.Title }}</title>
     <id>{{ .Site.BaseURL }}</id>
     <updated>{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}</updated>
-    {{ with $.Site.Author.name }}
+    {{ with $.Site.Params.Author.name }}
     <author><name>{{ . }}</name></author>
     {{ end }}
 


### PR DESCRIPTION
Running `hugo server` on latest version of Hugo will give this error:

```
hugo v0.145.0 linux/amd64 BuildDate=unknown

ERROR deprecated: .Site.Author was deprecated in Hugo v0.124.0 and subsequently removed. Implement taxonomy 'author' or use .Site.Params.Author instead.
Built in 70 ms
Error: error building site: logged 1 error(s)
```

This PR fixes the error. I've confirmed that the author still shows up in the generated RSS feed.