### PR TITLE
Improve systemd socket activation doc 

### DIFF
--- a/content/docs/howto.md
+++ b/content/docs/howto.md
@@ -220,7 +220,6 @@ Create a file `/etc/systemd/system/miniflux.service`:
 
     [Unit]
     Description=Miniflux Service
-    Requires=miniflux.socket
 
     [Service]
     ExecStart=/usr/bin/miniflux
@@ -228,13 +227,9 @@ Create a file `/etc/systemd/system/miniflux.service`:
     User=miniflux
     NonBlocking=true
 
-    [Install]
-    WantedBy=multi-user.target
-
 Enable this:
 
     sudo systemctl enable miniflux.socket
-    sudo systemctl enable miniflux.service
 
 Tell systemd to listen on port 80 for us:
 

--- a/content/docs/howto.md
+++ b/content/docs/howto.md
@@ -210,8 +210,13 @@ Create a file `/etc/systemd/system/miniflux.socket`:
     NoDelay=true
 
     # Listen on port 80.
-    # To use a unix socket, define the absolute path here.
     ListenStream=80
+
+    ## Unix Socket example
+    # ListenStream=/run/miniflux.sock
+    ## Optional: Only allow Webserver(e.g. caddy) to access the socket
+    # SocketGroup=caddy
+    # SocketMode=0660    
 
     [Install]
     WantedBy=sockets.target


### PR DESCRIPTION
Changes:
1. When using socket activation, the service need not be enabled as socket will start as needed.
2. Service unit has implicit dependency on socket, `Requires=...` is not needed
3. Add unix socket example