### PR TITLE
Add ReadKit to third-party applications

### DIFF
--- a/content/docs/apps.md
+++ b/content/docs/apps.md
@@ -19,6 +19,7 @@ Table of Contents
 - [NewsFlash](https://gitlab.com/news-flash/news_flash_gtk) (Linux / FOSS)
 - [ReactFlux](#ReactFlux) (Web frontend)
 - [Read You](https://github.com/Ashinch/ReadYou) (Android / FOSS)
+- [ReadKit](https://readkit.app/) (iOS/macOS / Freemium / Proprietary)
 - [Reeder Classic](http://reederapp.com/classic) (iOS/macOS / Paid / Proprietary)
 - [Reminiflux](#reminiflux) (Web frontend)
 - [RSS Guard](https://github.com/martinrotter/rssguard) (Windows, Linux, BSD, OS/2 or macOS / FOSS)


### PR DESCRIPTION
I have been using [ReadKit](https://readkit.app/) with Miniflux on my iPhone and iPad. It works great and has a very clean design.

They have recently added support for native Miniflux APIs, although it was already perfectly usable with Miniflux's Fever API emulation.

I think it should be on this list. 