### PR TITLE
Add Capy Reader to compatible apps

### DIFF
--- a/content/docs/apps.md
+++ b/content/docs/apps.md
@@ -5,6 +5,7 @@ url: /docs/apps.html
 
 Table of Contents
 
+- [Capy Reader](https://capyreader.com/) (Android / FOSS)
 - [FeedMe](https://play.google.com/store/apps/details?id=com.seazon.feedme&hl=en) (Android / Free / Proprietary)
 - [Fluent Reader](https://hyliu.me/fluent-reader/) (All platforms / FOSS except iPhone and Android non-free versions)
 - [Fluxjs](#fluxjs) (Web frontend)

--- a/content/docs/google_reader.md
+++ b/content/docs/google_reader.md
@@ -11,9 +11,10 @@ To activate the Google Reader API, go to the **Settings > Integrations** section
 
 ## Compatible Apps
 
+- [Capy Reader](https://capyreader.com/) (Android)
+- [NetNewsWire](https://netnewswire.com/) (iOS/macOS)
 - [Reeder Classic >= 5](http://reederapp.com/classic) (iOS/macOS)
 - [RSS Guard](https://github.com/martinrotter/rssguard)
-- [NetNewsWire](https://netnewswire.com/) (iOS/macOS)
 
 ## Notes
 


### PR DESCRIPTION
Capy Reader fully supports Miniflux via the Google Reader API. This change updates the docs to reflect that.