### PR TITLE
docs: Document the /v1/entries/ids API endpoint.

### DIFF
--- a/content/docs/api.md
+++ b/content/docs/api.md
@@ -1137,7 +1137,7 @@ Response
 ```
 
 <div class="info">
-This API endpoint is available since Miniflux v2.4.
+This API endpoint is available since Miniflux v2.3.2.
 </div>
 
 <h3 id="endpoint-update-entries">Update Entries <a class="anchor" href="#endpoint-update-entries" title="Permalink">¶</a></h3>

--- a/content/docs/api.md
+++ b/content/docs/api.md
@@ -34,6 +34,7 @@ Table of Contents:
     - [Get Feed Entries](#endpoint-get-feed-entries)
     - [Get Category Entries](#endpoint-get-category-entries)
     - [Get Entries](#endpoint-get-entries)
+    - [Get Entry IDs](#endpoint-get-entry-ids)
     - [Update Entries status](#endpoint-update-entries)
     - [Toggle Entry Bookmark](#endpoint-toggle-bookmark)
     - [Get Enclosure](#endpoint-get-enclosure)
@@ -1107,6 +1108,37 @@ Response:
     ]
 }
 ```
+
+<h3 id="endpoint-get-entry-ids">Get Entry IDs <a class="anchor" href="#endpoint-get-entry-ids" title="Permalink">¶</a></h3>
+
+Return a list of ID values for entries meeting the specified criteria. Results are limited to 10,000 ID values per response by default.
+
+Request:
+
+    GET /v1/entries/ids?status=unread
+
+Available filters:
+
+- `status`: Entry status (read or unread)
+- `starred`: true or false
+- `offset`
+- `limit`: Maximum 10,000
+
+Response
+
+```json
+{
+    "total": 2,
+    "entry_ids": [
+        15548,
+        15540
+    ]
+}
+```
+
+<div class="info">
+This API endpoint is available since Miniflux v2.4.
+</div>
 
 <h3 id="endpoint-update-entries">Update Entries <a class="anchor" href="#endpoint-update-entries" title="Permalink">¶</a></h3>
 


### PR DESCRIPTION
This documents the `/v1/entries/ids` API endpoint added in this pull request:
https://github.com/miniflux/v2/pull/4372

Notes:

- There is no release with this API endpoint. You may wish to hold off merging this until there is such a release.
- I wrote that this is available since Miniflux v2.4, but I do not know if that is the right version number. I am happy to change that.